### PR TITLE
Add simple docs section

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,8 @@
+# Getting Started
+
+Welcome to the documentation site. This page describes how to get started.
+
+- Install dependencies
+- Run the development server
+
+Enjoy!

--- a/docs/guide/intro.md
+++ b/docs/guide/intro.md
@@ -1,0 +1,5 @@
+# Guide Introduction
+
+This is the introduction to the guide section.
+
+More content will be added later.

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,15 @@
+import { getDocContent, parseMarkdown } from "@/lib/docs";
+import { notFound } from "next/navigation";
+
+export default function DocPage({ params }: { params: { slug?: string[] } }) {
+  const slug = params.slug ?? [];
+  if (slug.length === 0) {
+    return <p>Select a document from the navigation.</p>;
+  }
+  const content = getDocContent(slug);
+  if (content === null) {
+    notFound();
+  }
+  const html = parseMarkdown(content!);
+  return <article dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { getDocsTree, NavItem } from "@/lib/docs";
+import "../globals.css";
+
+function NavList({ items }: { items: NavItem[] }) {
+    if (!items.length) return null;
+    return (
+        <ul className="pl-4">
+            {items.map((item) => (
+                <li key={item.path} className="mb-1">
+                    {item.children ? (
+                        <>
+                            <span className="font-semibold">{item.title}</span>
+                            <NavList items={item.children} />
+                        </>
+                    ) : (
+                        <Link href={`/docs/${item.path}`}>{item.title}</Link>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+export default function DocsLayout({ children }: { children: ReactNode }) {
+    const nav = getDocsTree();
+    return (
+        <div className="flex min-h-screen">
+            <aside className="w-60 border-r p-4 overflow-y-auto">
+                <NavList items={nav} />
+            </aside>
+            <main className="flex-1 p-4 overflow-y-auto">{children}</main>
+        </div>
+    );
+}

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,110 @@
+import fs from "fs";
+import path from "path";
+
+export const DOCS_ROOT = path.join(process.cwd(), "docs");
+
+export type NavItem = {
+  title: string;
+  path: string; // path relative to docs root without extension
+  children?: NavItem[];
+};
+
+export function getDocTitle(filePath: string): string {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    const match = content.match(/^#\s+(.*)/);
+    if (match) {
+      return match[1].trim();
+    }
+  } catch {
+    // ignore
+  }
+  return path.basename(filePath).replace(/\.mdx?$/, "");
+}
+
+export function getDocsTree(dir: string = DOCS_ROOT, base = ""): NavItem[] {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  const items: NavItem[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.join(base, entry.name);
+    if (entry.isDirectory()) {
+      const children = getDocsTree(fullPath, relPath);
+      items.push({ title: entry.name, path: relPath, children });
+    } else if (/\.mdx?$/.test(entry.name)) {
+      const title = getDocTitle(fullPath);
+      items.push({
+        title,
+        path: relPath.replace(/\.mdx?$/, ""),
+      });
+    }
+  }
+  return items;
+}
+
+export function getDocContent(slug: string[]): string | null {
+  const basePath = path.join(DOCS_ROOT, ...slug);
+  const mdPath = `${basePath}.md`;
+  const mdxPath = `${basePath}.mdx`;
+  if (fs.existsSync(mdPath)) {
+    return fs.readFileSync(mdPath, "utf8");
+  }
+  if (fs.existsSync(mdxPath)) {
+    return fs.readFileSync(mdxPath, "utf8");
+  }
+  return null;
+}
+
+export function parseMarkdown(md: string): string {
+  const escapeHtml = (str: string) =>
+    str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  const lines = md.split(/\r?\n/);
+  let html = "";
+  let inList = false;
+
+  for (const line of lines) {
+    if (/^###\s+/.test(line)) {
+      if (inList) {
+        html += "</ul>";
+        inList = false;
+      }
+      html += `<h3>${escapeHtml(line.replace(/^###\s+/, ""))}</h3>`;
+    } else if (/^##\s+/.test(line)) {
+      if (inList) {
+        html += "</ul>";
+        inList = false;
+      }
+      html += `<h2>${escapeHtml(line.replace(/^##\s+/, ""))}</h2>`;
+    } else if (/^#\s+/.test(line)) {
+      if (inList) {
+        html += "</ul>";
+        inList = false;
+      }
+      html += `<h1>${escapeHtml(line.replace(/^#\s+/, ""))}</h1>`;
+    } else if (/^-\s+/.test(line)) {
+      if (!inList) {
+        html += "<ul>";
+        inList = true;
+      }
+      html += `<li>${escapeHtml(line.replace(/^-\s+/, ""))}</li>`;
+    } else if (line.trim() === "") {
+      if (inList) {
+        html += "</ul>";
+        inList = false;
+      }
+    } else {
+      if (inList) {
+        html += "</ul>";
+        inList = false;
+      }
+      html += `<p>${escapeHtml(line)}</p>`;
+    }
+  }
+  if (inList) {
+    html += "</ul>";
+  }
+  return html;
+}


### PR DESCRIPTION
## Summary
- add `docs` folder with example docs
- implement a basic markdown loader in `src/lib/docs.ts`
- create `/docs` layout with sidebar navigation
- add catch-all docs page to render markdown

## Testing
- `npm run lint` *(fails: `next` not found)*